### PR TITLE
Rsync script

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -17,6 +17,7 @@
    - wget
    - sendmail
    - which
+   - mc
 
 # Create the jenkins user
 - user: name=jenkins comment="Jenkins user" shell=/bin/bash state=present generate_ssh_key=yes

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -19,6 +19,7 @@
    - which
    - mc
    - vim
+   - htop
 
 # Create the jenkins user
 - user: name=jenkins comment="Jenkins user" shell=/bin/bash state=present generate_ssh_key=yes

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -18,6 +18,7 @@
    - sendmail
    - which
    - mc
+   - vim
 
 # Create the jenkins user
 - user: name=jenkins comment="Jenkins user" shell=/bin/bash state=present generate_ssh_key=yes

--- a/roles/jenkins/tasks/main.yml
+++ b/roles/jenkins/tasks/main.yml
@@ -113,3 +113,6 @@
 
 - name: Ensure Apache HTTPD is started now, and again on startup
   service: name=httpd enabled=yes state=restarted
+
+- name: Generate the script to synchronize tools on slaves
+  template: src=transfer-to-slaves-script dest=/home/jenkins/transfer-to-slaves.sh owner=jenkins mode=0744

--- a/roles/jenkins/templates/transfer-to-slaves-script
+++ b/roles/jenkins/templates/transfer-to-slaves-script
@@ -1,0 +1,16 @@
+#!/bin/bash
+# NOTE: each single whitespace and newline close to the template is important!
+# - the script might stop to request an interactive confirmation of the host signature
+# - it's expected to run this as user 'jenkins' as it will have the right keys setup 
+
+transfer() {
+   rsync --delete-during --archive --compress --progress --human-readable --one-file-system --stats ~/jboss-releases.txt $DESTINATION:~
+   rsync --delete-during --archive --compress --progress --human-readable --one-file-system --stats ~/jdk* $DESTINATION:~
+   rsync --delete-during --archive --compress --progress --human-readable --one-file-system --stats ~/.m2/settings* $DESTINATION:~/.m2
+}
+
+for DESTINATION in {% for host in groups['cislaves'] %}"{{ host }}" {% endfor %}
+
+do
+   transfer
+done


### PR DESCRIPTION
The first 3 commits add some tools that I find useful to have on the machine, they are not required.

The last commit, https://github.com/hibernate/ci.hibernate.org/commit/c845bb1269b7368dab756d5b77cf3a7a98a22e25, will change the original script proposed by @Sanne  to be inclusive instead of exclusive.

It will copy the boss-releases.txt, JDKs and maven settings* from master to slave

