### PR TITLE
Builds to run on a Ram drive

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -20,8 +20,9 @@
    - mc
    - vim
 
-# Create the jenkins user
-- user: name=jenkins comment="Jenkins user" shell=/bin/bash state=present generate_ssh_key=yes
+# Create the jenkins user and explicitly set gid and uid
+- group: name=jenkins state=present gid=1001
+- user: name=jenkins comment="Jenkins user" shell=/bin/bash state=present generate_ssh_key=yes uid=1001
 
 # Fetch the public key of this node
 - fetch: src=/home/jenkins/.ssh/id_rsa.pub dest=/tmp/publicdeployedkeys/pubkey-{{ ansible_hostname }} flat=yes fail_on_missing=yes

--- a/roles/inrelationto/files/httpd-inrelationto-config
+++ b/roles/inrelationto/files/httpd-inrelationto-config
@@ -2,6 +2,7 @@
   ServerName in.relation.to
   ServerAdmin webmaster@localhost
   ProxyRequests Off
+  AddOutputFilterByType DEFLATE text/html text/plain text/xml application/x-javascript text/css
 
   DocumentRoot /var/www/in.relation.to
   <Directory /var/www/in.relation.to>

--- a/roles/inrelationto/files/httpd-staginginrelationto-config
+++ b/roles/inrelationto/files/httpd-staginginrelationto-config
@@ -2,6 +2,7 @@
   ServerName staging.in.relation.to
   ServerAdmin webmaster@localhost
   ProxyRequests Off
+  AddOutputFilterByType DEFLATE text/html text/plain text/xml application/x-javascript text/css
 
   DocumentRoot /var/www/staging-in.relation.to
   <Directory /var/www/staging-in.relation.to>

--- a/roles/jenkins-slave/tasks/main.yml
+++ b/roles/jenkins-slave/tasks/main.yml
@@ -63,14 +63,10 @@
 
 # Gems required for web-site build
 - name: Install Rake
-  sudo: yes
-  sudo_user: jenkins
-  command: bash -lc "gem install rake"
+  gem: name=rake state=latest
 
 - name: Install Bundler
-  sudo: yes
-  sudo_user: jenkins
-  command: bash -lc "gem install bundler"
+  gem: name=bundler state=latest
 
 # Some slaves need to run rsync on the master,
 # this will ensure master is added to the known_host

--- a/roles/jenkins-slave/tasks/main.yml
+++ b/roles/jenkins-slave/tasks/main.yml
@@ -14,6 +14,9 @@
 - name: Create /mnt/jenkins-workdir
   file: path=/mnt/jenkins-workdir owner=jenkins group=jenkins mode=0755 state=directory
 
+- name: Make /mnt/jenkins-workdir a fast tmpfs drive
+  mount: name=/mnt/jenkins-workdir src=tmpfs fstype=tmpfs opts="rw,nosuid,nodev,relatime,seclabel,size=4g,uid=1001,gid=1001,mode=1700" state=mounted
+
 - name: Remove directory /var/lib/jenkins
   file: path=/var/lib/jenkins state=absent
 

--- a/roles/os1/tasks/main.yml
+++ b/roles/os1/tasks/main.yml
@@ -19,3 +19,23 @@
 # We leave this on /mnt as default as it's hell to move (and default is ext3)
 - name: Mount the ephemeral store drive as /mnt
   mount: name=/mnt src=/dev/vdb fstype=ext3 opts=noatime,barrier=0 state=mounted
+
+# Add 16GB swap space!
+# Important to use generous tmpfs sizes during builds
+
+- name: Ensure we have some swap space
+  shell: "dd if=/dev/zero of=/mnt/swapfile bs=1024 count=16777216 && mkswap /mnt/swapfile && swapon /mnt/swapfile"
+  args:
+    creates: /mnt/swapfile
+
+- name: Make the swap file secure
+  file: path=/mnt/swapfile state=touch mode="0600" owner="root" group="root"
+
+- name: Update fstab to use the swapfile on reboot
+  mount: name=none
+         src=/mnt/swapfile
+         fstype=swap
+         opts=sw
+         passno=0
+         dump=0
+         state=present


### PR DESCRIPTION
- Enable a 16GB swap space (in loopback on a file as we can't repartition)
- Mount the Jenkins workspace on a 4GB *tmpfs* drive

This should give us better memory efficiency than before (as we didn't have any swap space) and also speedup compilations a bit.

There is no data loss as this affects slaves only, while build reports are transferred to the master during the build.