### PR TITLE
Fix building of native extensions of gems on Fedora 23

### DIFF
--- a/roles/jenkins-slave/tasks/main.yml
+++ b/roles/jenkins-slave/tasks/main.yml
@@ -88,13 +88,25 @@
    - libxslt
    - libxslt-devel
    - rubygem-nokogiri
+   - findutils
+   - git
+   - ruby
+   - rpm-build
+  tags:
+    - websitegems
 
 # Gems required for web-site build
 - name: Install Rake
-  gem: name=rake state=latest
+  gem: name=rake state=latest user_install=yes
+  sudo_user: jenkins
+  tags:
+    - websitegems
 
 - name: Install Bundler
-  gem: name=bundler state=latest
+  gem: name=bundler state=latest user_install=yes
+  sudo_user: jenkins
+  tags:
+    - websitegems
 
 # Some slaves need to run rsync on the master,
 # this will ensure master is added to the known_host


### PR DESCRIPTION
there were two problems:
 - rake and bundler not being installed for the right user
 - various extensions now require the "rpm-build" package

The error message is as usual extremely unhelpful, it took me ages to figure this out.