### PR TITLE
Improve hostnames configuration

### DIFF
--- a/hosts
+++ b/hosts
@@ -7,7 +7,7 @@
 [awscislaves]
 
 [cimaster]
-54.174.65.136 ansible_ssh_private_key_file=~/.ssh/keys/hibernate-keys-aws.pem ansible_ssh_user=ec2-user
+54.174.65.136 ansible_ssh_private_key_file=~/.ssh/keys/hibernate-keys-aws.pem ansible_ssh_user=ec2-user hostname=ci
 
 [dedicated]
-209.132.179.20 ansible_ssh_private_key_file=~/.ssh/keys/hibernate-keys-os1.pem
+209.132.179.20 ansible_ssh_private_key_file=~/.ssh/keys/hibernate-keys-os1.pem hostname=cidedicated

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -27,6 +27,17 @@
      - Wait for server to restart
   when: (ansible_distribution == "Fedora" and ansible_distribution_major_version >= "23")
 
+# Hostname and hosts file
+- name: Set the hostname
+  hostname: name={{ hostname }}
+  tags:
+    - hostname
+
+- name: Setup the hosts file to workaround Java RMI limitations
+  template: src=hosts dest=/etc/hosts
+  tags:
+    - hostname
+
 # Create the jenkins user and explicitly set gid and uid
 - group: name=jenkins state=present gid=1001
 - user: name=jenkins comment="Jenkins user" shell=/bin/bash state=present generate_ssh_key=yes uid=1001

--- a/roles/common/templates/hosts
+++ b/roles/common/templates/hosts
@@ -1,0 +1,3 @@
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4 {{ hostname }}
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+999.999.999.999	nothere

--- a/roles/jenkins-slave/tasks/main.yml
+++ b/roles/jenkins-slave/tasks/main.yml
@@ -60,11 +60,6 @@
   tags:
     - jenkins
 
-# It's nice to have it and sometimes a hostname too long can cause problems
-- name: Set the hostname
-  hostname: name={{ hostname }}
-
-
 - name: Run Cassandra docker image
   docker_container:
     name: cassandra


### PR DESCRIPTION
Relates to this failure:
 - http://ci.hibernate.org/job/hibernate-search-PR/org.hibernate$hibernate-search-integrationtest-osgi/1962/testReport/junit/org.hibernate.search.test.integration.osgi/SystemTest/testLocalhostResolution/

The trick is to mention the local machine name in the 127.0.0.1 line of the /etc/hosts file.