### PR TITLE
Docker compose

### DIFF
--- a/roles/jenkins-slave/tasks/main.yml
+++ b/roles/jenkins-slave/tasks/main.yml
@@ -24,11 +24,12 @@
     - docker
     - groups
 
-- name: Docker engine
+- name: Docker engine and Docker Compose
   dnf: name={{item}} state=latest
   with_items:
     - python-docker-py
     - docker-engine
+    - docker-compose
   tags:
     - docker
 


### PR DESCRIPTION
Commit on top of https://github.com/hibernate/ci.hibernate.org/pull/47

At the moment it is only used by the cockroach module but we are using docker more and more
and it might come in handy.